### PR TITLE
Fix Docker workflow digest reference

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Export digest
         run: |
           mkdir -p /tmp/digests
-          digest="${{ steps.docker-build.outputs.digest }}"
+          digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
       - name: Upload digest
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- Correct digest step reference in GitHub Actions Docker workflow
- Update step name from 'docker-build' to 'build' for digest extraction