### PR TITLE
Add coverage configuration for test exclusions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Export digest
         run: |
           mkdir -p /tmp/digests
-          digest="${{ steps.docker-build.outputs.digest }}"
+          digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
       - name: Upload digest
         uses: actions/upload-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,3 +50,6 @@ namespaces = false
 
 [tool.pytest.ini_options]
 log_cli_level = "DEBUG"
+
+[tool.coverage.run]
+omit = ["pywssocks/cli.py", "pywssocks/__init__.py"]


### PR DESCRIPTION
- Exclude cli.py and __init__.py from coverage reporting
- Update pyproject.toml with coverage run settings