### PR TITLE
Add feature: ignore ssl validation

### DIFF
--- a/pywssocks/cli.py
+++ b/pywssocks/cli.py
@@ -101,6 +101,14 @@ def cli():
     help="Specify connector token for reverse proxy",
 )
 @click.option("--debug", "-d", is_flag=True, default=False, help="Show debug logs")
+@click.option(
+    "--ignore-ssl",
+    "-k",
+    default=False,
+    is_flag=True,
+    help="Disable SSL validation"
+)
+
 def _client_cli(
     token: str,
     url: str,
@@ -114,6 +122,7 @@ def _client_cli(
     upstream_proxy: Optional[str],
     connector_token: Optional[str],
     debug: bool,
+    ignore_ssl: bool,
 ):
     """Start SOCKS5 over WebSocket proxy client"""
 
@@ -144,6 +153,7 @@ def _client_cli(
             upstream_proxy=upstream_host,
             upstream_username=upstream_username,
             upstream_password=upstream_password,
+            ignore_ssl=ignore_ssl,
         )
 
         task = await client.wait_ready()


### PR DESCRIPTION
This PR adds a new command line option to the pywssocks client that ignores SSL validation errors.
This is accomplished by providing a custom SSL context to the websocket connect method in the `_start_forward` and `_start_reverse` functions when the command line argument `-k, --ignore-ssl` is specified. 
Example usage:
`pywssocks client -u https://192.168.1.10:8080/ -r -t asdfasdf -k`